### PR TITLE
Start on `lazy` module with `Thunk` datatype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,14 @@ pub mod lazy {
     #[derive(Copy, Clone)]
     pub struct Thunk<T: Clone, F: FnOnce() -> T> {
         _think: F,
-        _val: Option<T>,
+        _memo: Option<T>,
     }
 
     impl<T: Clone, F: FnOnce() -> T> Thunk<T, F> {
         pub fn new(closure: F) -> Thunk<T, F> {
             Thunk {
                 _think: closure,
-                _val: None,
+                _memo: None,
             }
         }
 
@@ -18,11 +18,11 @@ pub mod lazy {
         }
 
         pub fn force(mut self) -> T {
-            match self._val {
+            match self._memo {
                 Some(v) => v,
                 None => {
                     let rv = self.think();
-                    self._val = Some(rv.clone());
+                    self._memo = Some(rv.clone());
                     rv
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,15 +13,12 @@ pub mod lazy {
             }
         }
 
-        fn think(self) -> T {
-            (self._think)()
-        }
-
         pub fn force(mut self) -> T {
             match self._memo {
                 Some(v) => v,
                 None => {
-                    let rv = self.think();
+                    let think = self._think;
+                    let rv = think();
                     self._memo = Some(rv.clone());
                     rv
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
     use lazy::Thunk;
 
     #[test]
-    fn it_works() {
+    fn it_defers_application_until_forced() {
         let t = Thunk::new(|| 5);
         let v = t.force();
         assert_eq!(v, 5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,28 @@
 pub mod lazy {
-    pub struct Thunk<T, F: FnOnce() -> T> {
+    #[derive(Copy, Clone)]
+    pub struct Thunk<T: Clone, F: FnOnce() -> T> {
         _think: F,
         _val: Option<T>,
     }
 
-    impl <T, F: FnOnce() -> T> Thunk<T, F> {
+    impl<T: Clone, F: FnOnce() -> T> Thunk<T, F> {
         pub fn new(closure: F) -> Thunk<T, F> {
             Thunk {
                 _think: closure,
-                _val: None
+                _val: None,
             }
         }
 
-        pub fn force(self) -> T {
+        fn think(self) -> T {
+            (self._think)()
+        }
+
+        pub fn force(mut self) -> T {
             match self._val {
-                Some(v) =>
-                    v,
+                Some(v) => v,
                 None => {
-                    let think = self._think;
-                    let rv = think();
-                    //self._val = Some(rv);
+                    let rv = self.think();
+                    self._val = Some(rv.clone());
                     rv
                 }
             }
@@ -34,6 +37,14 @@ mod tests {
     #[test]
     fn it_works() {
         let t = Thunk::new(|| 5);
+        let v = t.force();
+        assert_eq!(v, 5);
+    }
+
+    #[test]
+    fn it_memoizes_values() {
+        let t = Thunk::new(|| 5);
+        t.force();
         let v = t.force();
         assert_eq!(v, 5);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,40 @@
+pub mod lazy {
+    pub struct Thunk<T, F: FnOnce() -> T> {
+        _think: F,
+        _val: Option<T>,
+    }
+
+    impl <T, F: FnOnce() -> T> Thunk<T, F> {
+        pub fn new(closure: F) -> Thunk<T, F> {
+            Thunk {
+                _think: closure,
+                _val: None
+            }
+        }
+
+        pub fn force(self) -> T {
+            match self._val {
+                Some(v) =>
+                    v,
+                None => {
+                    let think = self._think;
+                    let rv = think();
+                    //self._val = Some(rv);
+                    rv
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use lazy::Thunk;
+
     #[test]
     fn it_works() {
-        assert_eq!(2 + 2, 4);
+        let t = Thunk::new(|| 5);
+        let v = t.force();
+        assert_eq!(v, 5);
     }
 }


### PR DESCRIPTION
This adds `Thunk` and it's affiliated methods for forcing a value out of it (as well as memoising said value). 

- [ ] The memoisation test could probably be improved to use a different method passed to `Thunk::new`