### PR TITLE
Lazy Streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub mod lazy {
         _cell: RefCell<Rc<Thunk<'a, Cell<'a, T>>>>
     }
 
+    impl <'a, T> Stream<'a, T> {
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod lazy {
             self._v.clone()
         }
 
-        pub fn pop_front(self) -> Option<Stream<'a, T>> {
+        pub fn tail(self) -> Option<Stream<'a, T>> {
             self._tail
         }
     }
@@ -117,10 +117,10 @@ pub mod lazy {
             }
         }
 
-        pub fn pop_front(&self) -> Stream<'a, T> {
+        pub fn tail(&self) -> Stream<'a, T> {
             let old_strm =
                 match self.unwrap_cell() {
-                    Some(cell) => cell.pop_front(),
+                    Some(cell) => cell.tail(),
                     None => None,
                 };
             match old_strm {
@@ -138,7 +138,7 @@ pub mod lazy {
                 return None;
             }
             let curr = self.get();
-            self._cell.replace(self.pop_front()._cell.into_inner());
+            self._cell.replace(self.tail()._cell.into_inner());
             curr
         }
     }
@@ -180,7 +180,7 @@ mod tests {
 
             assert_eq!(strm.get(), Some(i));
             i += 1;
-            strm = strm.pop_front();
+            strm = strm.tail();
         }
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
             assert_eq!(strm.get(), Some(i));
             i += 1;
-            strm = strm.pop_front();
+            strm = strm.tail();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod lazy {
-    //use std::rc::Rc;
+    use std::rc::Rc;
     use std::cell::RefCell;
 
     pub struct Thunk<'a, T> {
@@ -7,7 +7,7 @@ pub mod lazy {
         _think: Box<'a + Fn() -> T>,
     }
 
-    impl <'a, T> Thunk<'a, T> {
+    impl <'a, T: Clone> Thunk<'a, T> {
         pub fn new<F>(clsr: F) -> Thunk<'a, T> where F: 'a + Fn() -> T {
             Thunk {
                 _think: Box::new(clsr),
@@ -15,70 +15,17 @@ pub mod lazy {
             }
         }
 
-        pub fn force(self) -> Option<T> {
+        pub fn force(&self) -> T {
             if self._thunk.borrow().is_none() {
                 let rv = (self._think)();
                 self._thunk.replace(Some(rv));
             }
-            self._thunk.into_inner()
+            self._thunk
+                .clone()
+                .into_inner()
+                .unwrap()
         }
     }
-
-    //pub struct Cell<T> {
-        //pub head: T,
-        //tail: Stream<T>,
-    //}
-
-    //impl <T> Cell<T> {
-        //pub fn new(x: T, tail: Stream<T>) -> Cell<T> {
-            //Cell {
-                //head: x,
-                //tail: tail,
-            //}
-        //}
-    //}
-
-    //pub struct Stream<T> {
-        //_cell: Rc<Thunk<Cell<T>>>
-    //}
-
-    //impl <T> Stream<T> {
-        //// TODO For finite lists.
-        ////pub fn empty() {
-            ////Stream {
-                ////_cell: None
-            ////}
-        ////}
-
-        //pub fn get(self) -> Option<T> {
-            //Rc::try_unwrap(self._cell)
-        //}
-
-        //pub fn new(f: Box<Fn() -> Cell<T>>) -> Stream<T> {
-            //Stream {
-                //_cell: Rc::new(Thunk::new(f))
-            //}
-        //}
-    //}
-
-    //impl <T> Iterator for Stream<T> {
-        //type Item = Rc<Thunk<Cell<T>>>;
-
-        //fn next(&mut self) -> Option<Self::Item> {
-            //match Rc::try_unwrap(self._cell.clone()) {
-                //Ok(thunk) => {
-                    //match thunk.force() {
-                        //Some(cell) => {
-                            //self._cell = cell.tail._cell;
-                            //Some(self._cell.clone())
-                        //},
-                        //None => None
-                    //}
-                //},
-                //_ => None,
-            //}
-        //}
-    //}
 }
 
 #[cfg(test)]
@@ -91,28 +38,20 @@ mod tests {
     fn thunks_defer_application_until_forced() {
         let t = Thunk::new(|| 5);
         let v = t.force();
-        assert_eq!(v, Some(5));
+        assert_eq!(v, 5);
     }
 
     #[test]
     fn thunks_memoize_values() {
         let t = Thunk::new(|| SystemTime::now());
-        let p = t.force().unwrap();
-        let q = p;
+        let p = t.force();
+        let q = t.force();
         assert_eq!(p, q);
     }
 
     //#[test]
-    //fn streams_are_lazy_and_infinite() {
-        //fn ints_from(n: usize) -> Stream<usize> {
-            //Stream::new(Box::new(move || Cell::new(n, ints_from(n+1))))
-        //}
-
-        //let mut strm = ints_from(5);
-        //let x = strm.next();
-        ////assert_eq!(strm.take(5).count(), 5);
-        ////for x in strm.iter().take(5) {
-            ////assert_eq!(x, x); // Not valid!
-        ////}
+    //fn lazy_cells_have_a_head_and_a_tail() {
+        //let cell = Cell::new(13, Stream::empty());
+        //let x:() = cell.head;
     //}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,19 @@ pub mod lazy {
                 .unwrap()
         }
     }
+
+    pub struct Cell<'a, T> {
+        _v: T,
+        _tail: Stream<'a, T>,
+    }
+
+    impl <'a, T> Cell<'a, T> {
+    }
+
+    pub struct Stream<'a, T> {
+        _cell: RefCell<Rc<Thunk<'a, Cell<'a, T>>>>
+    }
+
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,61 @@
 pub mod lazy {
+    use std::rc::{Rc};
+
     pub struct Thunk<T> {
-        _think: Box<Fn() -> T>,
         _memo: Option<T>,
+        _think: Box<Fn() -> T>,
     }
 
-    impl<T: Clone + Copy> Thunk<T> {
-        pub fn new(closure: Box<Fn() -> T>) -> Thunk<T> {
+    impl <T> Thunk<T> {
+        pub fn new(clsr: Box<Fn() -> T>) -> Thunk<T> {
             Thunk {
-                _think: closure,
+                _think: clsr,
                 _memo: None,
             }
         }
 
-        pub fn force(&mut self) -> T {
+        pub fn force(&mut self) -> &Option<T> {
             match self._memo {
-                Some(v) => v,
                 None => {
-                    let think = &self._think;
-                    let rv = think();
-                    //let rv = (self._think)();
-                    self._memo = Some(rv.clone());
-                    rv
+                    let rv = (self._think)();
+                    self._memo = Some(rv);
                 }
+                _ => ()
+            }
+            &self._memo
+        }
+    }
+
+    pub struct Cell<T> {
+        _v: T,
+        _tail: Stream<T>,
+    }
+
+    impl <T> Cell<T> {
+        pub fn new(x: T, tail: Stream<T>) -> Cell<T> {
+            Cell {
+                _v: x,
+                _tail: tail,
+            }
+        }
+
+        pub fn head(self) -> T {
+            self._v
+        }
+
+        pub fn tail(self) -> Stream<T> {
+            self._tail
+        }
+    }
+
+    pub struct Stream<T> {
+        _cell: Rc<Thunk<Cell<T>>>
+    }
+
+    impl <T> Stream<T> {
+        pub fn new(self, f: Box<Fn() -> Cell<T>>) -> Stream<T> {
+            Stream {
+                _cell: Rc::new(Thunk::new(f))
             }
         }
     }
@@ -34,16 +68,16 @@ mod tests {
 
     #[test]
     fn it_defers_application_until_forced() {
-        let mut t = Thunk::new(|| 5);
-        let v = t.force();
+        let mut t = Thunk::new(Box::new(|| 5));
+        let v = t.force().unwrap();
         assert_eq!(v, 5);
     }
 
     #[test]
     fn it_memoizes_values() {
-        let mut t = Thunk::new(|| SystemTime::now() );
-        let p = t.force();
-        let q = t.force();
+        let mut t = Thunk::new(Box::new(|| SystemTime::now()));
+        let p = t.force().unwrap();
+        let q = t.force().unwrap();
         assert_eq!(p, q);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,11 @@
 pub mod lazy {
-    #[derive(Copy, Clone)]
-    pub struct Thunk<T, F: (FnOnce() -> T) + Copy> {
-        _think: F,
+    pub struct Thunk<T> {
+        _think: Box<Fn() -> T>,
         _memo: Option<T>,
     }
 
-    impl<T: Clone + Copy, F: (FnOnce() -> T) + Copy> Thunk<T, F> {
-        pub fn new(closure: F) -> Thunk<T, F> {
+    impl<T: Clone + Copy> Thunk<T> {
+        pub fn new(closure: Box<Fn() -> T>) -> Thunk<T> {
             Thunk {
                 _think: closure,
                 _memo: None,
@@ -17,7 +16,9 @@ pub mod lazy {
             match self._memo {
                 Some(v) => v,
                 None => {
-                    let rv = (self._think)();
+                    let think = &self._think;
+                    let rv = think();
+                    //let rv = (self._think)();
                     self._memo = Some(rv.clone());
                     rv
                 }


### PR DESCRIPTION
This seems to have partially flushed out the need for `Copy` and `Clone` traits that `Thunk` was requiring on it's generic parameter. It's also changed the API of `force` a bit. I am still wondering if `force` should return a new `Thunk` 

- [x] Needs tests
- [x] Needs more of the API to be fleshed out (getting values, keeping things lazy)