### PR TITLE
Finish impl. for `towards`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-mod lazy;
-mod shrink;
+pub mod lazy;
+pub mod shrink;
 pub mod tree;

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -1,6 +1,6 @@
 extern crate num;
 
-use self::num::{FromPrimitive, Integer};
+use self::num::{Float, FromPrimitive, Integer};
 
 // This probably could be optimised for an eager language. by simply manipulating the vector
 // directly and doing the inner check, rather than returning the function here for use in a
@@ -23,7 +23,7 @@ where
 
 // TODO: This function needs testing and verification.
 // TODO: This function could just be a loop.
-fn unfold<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
+fn unfold<A, B>(f: impl Fn(B) -> Option<(A, B)>, b0: B) -> Vec<A> {
     match f(b0) {
         Some((a, b1)) => {
             let mut v = unfold(f, b1);
@@ -34,7 +34,6 @@ fn unfold<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
     }
 }
 
-#[allow(dead_code)]
 pub fn halves<A>(n: A) -> Vec<A>
 where
     A: Integer + FromPrimitive + Copy,
@@ -49,10 +48,9 @@ where
             Some((x0, x1))
         }
     };
-    unfold(Box::new(go), n)
+    unfold(go, n)
 }
 
-#[allow(dead_code)]
 /// Shrink an integral number by edging towards a destination.
 pub fn towards<'a, A: 'a>(destination: A) -> impl Fn(A) -> Vec<A>
 where
@@ -73,6 +71,33 @@ where
     towards_do
 }
 
+#[allow(dead_code)]
+/// Shrink a floating-point number by edging towards a destination.
+/// Note we always try the destination first, as that is the optimal shrink.
+pub fn towards_float<'a, A: 'a>(destination: A) -> impl Fn(A) -> Vec<A>
+where
+    A: Float + FromPrimitive + Copy,
+{
+    let towards_do = move |x: A| {
+        if destination == x {
+            Vec::new()
+        } else {
+            let diff = x - destination;
+            let go = |n| {
+                let x1 = x - n;
+                if x1 != x {
+                    let two = FromPrimitive::from_isize(2).unwrap();
+                    Some((x1, n / two))
+                } else {
+                    None
+                }
+            };
+            unfold(go, diff)
+        }
+    };
+    towards_do
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -81,5 +106,69 @@ mod test {
     fn towards_works() {
         let f = towards(3);
         assert_eq!(f(100), vec![3, 51, 76, 88, 94, 97, 99]);
+    }
+
+    #[test]
+    fn towards_float_works() {
+        let f = towards_float(100.0);
+
+        let expected = vec![
+            100.0,
+            300.0,
+            400.0,
+            450.0,
+            475.0,
+            487.5,
+            493.75,
+            496.875,
+            498.4375,
+            499.21875,
+            499.609375,
+            499.8046875,
+            499.90234375,
+            499.951171875,
+            499.9755859375,
+            499.98779296875,
+            499.993896484375,
+            499.9969482421875,
+            499.99847412109375,
+            499.9992370605469,
+            499.99961853027344,
+            499.9998092651367,
+            499.99990463256836,
+            499.9999523162842,
+            499.9999761581421,
+            499.99998807907104,
+            499.9999940395355,
+            499.99999701976776,
+            499.9999985098839,
+            499.99999925494194,
+            499.99999962747097,
+            499.9999998137355,
+            499.99999990686774,
+            499.99999995343387,
+            499.99999997671694,
+            499.99999998835847,
+            499.99999999417923,
+            499.9999999970896,
+            499.9999999985448,
+            499.9999999992724,
+            499.9999999996362,
+            499.9999999998181,
+            499.99999999990905,
+            499.9999999999545,
+            499.99999999997726,
+            499.99999999998863,
+            499.9999999999943,
+            499.99999999999716,
+            499.9999999999986,
+            499.9999999999993,
+            499.99999999999966,
+            499.99999999999983,
+            499.9999999999999,
+            499.99999999999994,
+        ];
+
+        assert_eq!(f(500.0), expected);
     }
 }

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -100,7 +100,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use super::*;
 
     #[test]
     fn towards_works() {

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -2,9 +2,59 @@ extern crate num;
 
 use self::num::{FromPrimitive, Num};
 
+// This probably could be optimised for an eager language. by simply manipulating the vector
+// directly and doing the inner check, rather than returning the function here for use in a
+// pipeline a la the F# port.
+fn cons_nub<'a, A: 'a>(x: A) -> Box<Fn(Vec<A>) -> Vec<A> + 'a>
+where
+    A: Num + FromPrimitive + Copy,
+{
+    let cons_nub_do = move |ys0: Vec<A>| {
+        let mut ys1 = ys0.clone();
+        if ys1.is_empty() {
+            vec![]
+        } else {
+            let y = ys1.remove(0);
+            if x == y {
+                ys0
+            } else {
+                ys1.insert(0, y);
+                ys1.insert(0, x);
+                ys1
+            }
+        }
+    };
+    Box::new(cons_nub_do)
+}
+
+// TODO: This function needs testing and verification.
+fn unfoldr<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
+    match f(b0) {
+        Some((a, b1)) => {
+            let mut v = unfoldr(f, b1);
+            v.insert(0, a); // XXX Always shifts values over on each fn call.
+            v
+        }
+        None => vec![],
+    }
+}
+
 #[allow(dead_code)]
-pub fn halves<A>(_n: A) -> Vec<A> {
-    vec![]
+pub fn halves<A>(n: A) -> Vec<A>
+where
+    A: Num + FromPrimitive + Copy,
+{
+    let go = |x0| {
+        let zero = num::zero();
+        if x0 == zero {
+            None
+        } else {
+            let two = FromPrimitive::from_isize(2).unwrap();
+            let x1 = x0 / two;
+            Some((x0, x1))
+        }
+    };
+    unfoldr(Box::new(go), n)
 }
 
 #[allow(dead_code)]
@@ -20,8 +70,19 @@ where
             let two = FromPrimitive::from_isize(2).unwrap();
             let diff = (x / two) - (destination / two);
 
-            halves(diff).into_iter().map(|y| x - y).collect()
+            cons_nub(destination)(halves(diff).into_iter().map(|y| x - y).collect())
         }
     };
     Box::new(towards_do)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn towards_shrinks() {
+        let f = towards(3);
+        assert_eq!(f(100), vec![3, 51, 76, 88, 94, 97, 99]);
+    }
 }

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -54,21 +54,23 @@ where
 
 #[allow(dead_code)]
 /// Shrink an integral number by edging towards a destination.
-pub fn towards<'a, A: 'a>(destination: A) -> Box<Fn(A) -> Vec<A> + 'a>
+pub fn towards<'a, A: 'a>(destination: A) -> impl Fn(A) -> Vec<A>
 where
-    A: Num + FromPrimitive + Copy,
+    A: Integer + FromPrimitive + Copy,
 {
     let towards_do = move |x: A| {
         if destination == x {
             Vec::new()
         } else {
+            // We need to halve our operands before subtracting them as they may be using
+            // the full range of the type (i.e. 'MinValue' and 'MaxValue' for 'Int32')
             let two = FromPrimitive::from_isize(2).unwrap();
             let diff = (x / two) - (destination / two);
 
             cons_nub(destination)(halves(diff).into_iter().map(|y| x - y).collect())
         }
     };
-    Box::new(towards_do)
+    towards_do
 }
 
 #[cfg(test)]

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -9,19 +9,13 @@ fn cons_nub<'a, A: 'a>(x: A) -> Box<Fn(Vec<A>) -> Vec<A> + 'a>
 where
     A: Num + FromPrimitive + Copy,
 {
-    let cons_nub_do = move |ys0: Vec<A>| {
-        let mut ys1 = ys0.clone();
-        if ys1.is_empty() {
-            vec![]
-        } else {
-            let y = ys1.remove(0);
-            if x == y {
-                ys0
-            } else {
-                ys1.insert(0, y);
-                ys1.insert(0, x);
-                ys1
-            }
+    let cons_nub_do = move |ys0: Vec<A>| match ys0.first() {
+        None => vec![],
+        Some(&y) if x == y => ys0,
+        Some(_) => {
+            let mut ys1 = ys0.clone();
+            ys1.insert(0, x);
+            ys1
         }
     };
     Box::new(cons_nub_do)

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -75,7 +75,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn towards_shrinks() {
+    fn towards_works() {
         let f = towards(3);
         assert_eq!(f(100), vec![3, 51, 76, 88, 94, 97, 99]);
     }

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -1,13 +1,13 @@
 extern crate num;
 
-use self::num::{FromPrimitive, Num};
+use self::num::{FromPrimitive, Integer};
 
 // This probably could be optimised for an eager language. by simply manipulating the vector
 // directly and doing the inner check, rather than returning the function here for use in a
 // pipeline a la the F# port.
 fn cons_nub<'a, A: 'a>(x: A) -> Box<Fn(Vec<A>) -> Vec<A> + 'a>
 where
-    A: Num + FromPrimitive + Copy,
+    A: Integer + FromPrimitive + Copy,
 {
     let cons_nub_do = move |ys0: Vec<A>| match ys0.first() {
         None => vec![],
@@ -22,6 +22,7 @@ where
 }
 
 // TODO: This function needs testing and verification.
+// TODO: This function could just be a loop.
 fn unfold<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
     match f(b0) {
         Some((a, b1)) => {
@@ -36,7 +37,7 @@ fn unfold<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
 #[allow(dead_code)]
 pub fn halves<A>(n: A) -> Vec<A>
 where
-    A: Num + FromPrimitive + Copy,
+    A: Integer + FromPrimitive + Copy,
 {
     let go = |x0| {
         let zero = num::zero();

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -28,10 +28,10 @@ where
 }
 
 // TODO: This function needs testing and verification.
-fn unfoldr<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
+fn unfold<A, B>(f: Box<Fn(B) -> Option<(A, B)>>, b0: B) -> Vec<A> {
     match f(b0) {
         Some((a, b1)) => {
-            let mut v = unfoldr(f, b1);
+            let mut v = unfold(f, b1);
             v.insert(0, a); // XXX Always shifts values over on each fn call.
             v
         }
@@ -54,7 +54,7 @@ where
             Some((x0, x1))
         }
     };
-    unfoldr(Box::new(go), n)
+    unfold(Box::new(go), n)
 }
 
 #[allow(dead_code)]

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -100,7 +100,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::*;
 
     #[test]
     fn towards_works() {


### PR DESCRIPTION
Much of this that does recursive calls will need translation to loops for optimisation and avoiding exhausting the stack, but this passes a menial example that produces the same value in `haskell-hedgehog` (see test).

This also marks the port of `towards`, and so there might be other shrinking fns that need porting as well from the same module. I'll have a look at the `R` and `F#` ports to get an idea.