### PR TITLE
Rename type variables from `T`, `U`, etc. to `A`, `B`, etc.

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -1,12 +1,12 @@
-pub struct Lazy<'a, T> {
-    value: Option<T>,
-    closure: Box<'a + Fn() -> T>,
+pub struct Lazy<'a, A> {
+    value: Option<A>,
+    closure: Box<'a + Fn() -> A>,
 }
 
-impl<'a, T: Clone> Lazy<'a, T> {
-    pub fn new<F>(closure: F) -> Lazy<'a, T>
+impl<'a, A: Clone> Lazy<'a, A> {
+    pub fn new<F>(closure: F) -> Lazy<'a, A>
     where
-        F: 'a + Fn() -> T,
+        F: 'a + Fn() -> A,
     {
         Lazy {
             closure: Box::new(closure),
@@ -14,14 +14,14 @@ impl<'a, T: Clone> Lazy<'a, T> {
         }
     }
 
-    fn force(&mut self) -> &T {
+    fn force(&mut self) -> &A {
         if self.value.is_none() {
             self.value = Some((self.closure)());
         }
         &self.value.as_ref().unwrap()
     }
 
-    pub fn value(&mut self) -> &T {
+    pub fn value(&mut self) -> &A {
         self.force()
     }
 }

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -71,7 +71,6 @@ where
     towards_do
 }
 
-#[allow(dead_code)]
 /// Shrink a floating-point number by edging towards a destination.
 /// Note we always try the destination first, as that is the optimal shrink.
 pub fn towards_float<'a, A: 'a>(destination: A) -> impl Fn(A) -> Vec<A>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,27 +1,36 @@
 use lazy::Lazy;
 
-#[allow(dead_code)]
-pub struct Tree<'a, T> {
-    thunk: Lazy<'a, T>,
-    children: Vec<Tree<'a, T>>,
+pub struct Tree<'a, A> {
+    thunk: Lazy<'a, A>,
+    children: Vec<Tree<'a, A>>,
 }
 
-impl<'a, T: 'a + Clone> Tree<'a, T> {
-    pub fn singleton(value: T) -> Tree<'a, T> {
+impl<'a, A: 'a + Clone> Tree<'a, A> {
+    pub fn singleton(value: A) -> Tree<'a, A> {
         Tree {
             thunk: Lazy::new(move || value.clone()),
             children: vec![],
         }
     }
 
-    pub fn value(&mut self) -> &T {
+    pub fn value(&mut self) -> &A {
         self.thunk.value()
+    }
+}
+
+pub fn render<'a, A>(root: &mut Tree<'a, A>)
+where
+    A: Clone + std::fmt::Debug + 'a,
+{
+    print!("\"{:?}\"", &mut root.value());
+    for child in root.children.iter_mut() {
+        render(child);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use tree::Tree;
+    use super::*;
 
     #[test]
     fn rose_trees_hold_lazy_values() {
@@ -30,5 +39,12 @@ mod tests {
         tree.value();
         tree.value();
         assert_eq!(*tree.value(), n);
+    }
+
+    #[test]
+    fn trees_get_rendered() {
+        let mut tree = Tree::singleton(3);
+        tree.children = vec![Tree::singleton(5)];
+        render(&mut tree);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -18,16 +18,6 @@ impl<'a, A: 'a + Clone> Tree<'a, A> {
     }
 }
 
-pub fn render<'a, A>(root: &mut Tree<'a, A>)
-where
-    A: Clone + std::fmt::Debug + 'a,
-{
-    print!("\"{:?}\"", &mut root.value());
-    for child in root.children.iter_mut() {
-        render(child);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -39,12 +29,5 @@ mod tests {
         tree.value();
         tree.value();
         assert_eq!(*tree.value(), n);
-    }
-
-    #[test]
-    fn trees_get_rendered() {
-        let mut tree = Tree::singleton(3);
-        tree.children = vec![Tree::singleton(5)];
-        render(&mut tree);
     }
 }


### PR DESCRIPTION
Teensy nitpick.