### PR TITLE
Port over seed module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Ryan James Spencer <spencer.ryanjames@gmail.com>"]
 num = "0.2"
 num-traits = "0.2"
 num-derive = "0.2"
+rand = "0.6"
+rand_core = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate num_derive;
 extern crate num;
+extern crate rand;
+extern crate rand_core;
 
 pub mod gen;
 pub mod lazy;

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,7 +1,118 @@
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+use rand::distributions::{Distribution, Uniform};
+use rand_core::{impls, RngCore};
+
+const GOLDEN_GAMMA: u64 = 0x9e3779b97f4a7c15;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct Seed {
     value: u64,
     gamma: u64,
+}
+
+// TODO
+pub fn global() -> Seed {
+    // Use /dev/urandom on linux
+    // otherwise get POSIX time
+    let value = 0;
+    let gamma = 0;
+    Seed { value, gamma }
+}
+
+// TODO
+pub fn random() -> Seed {
+    split(global())
+}
+
+// TODO
+pub fn from(x: u64) -> Seed {
+    let value = mix64(x);
+    let gamma = mix_gamma(x + GOLDEN_GAMMA);
+    Seed { value, gamma }
+}
+
+pub fn next(Seed { value, gamma }: Seed) -> (u64, Seed) {
+    let value = value + gamma;
+    (value, Seed { value, gamma })
+}
+
+pub fn split(s0: Seed) -> Seed {
+    let (v0, s1) = next(s0);
+    let (g0, _s2) = next(s1);
+    let value = mix64(v0);
+    let gamma = mix_gamma(g0);
+    Seed { value, gamma }
+}
+
+pub fn next_word64(s0: Seed) -> (u64, Seed) {
+    let (v0, s1) = next(s0);
+    (mix64(v0), s1)
+}
+
+pub fn next_word32(s0: Seed) -> (u32, Seed) {
+    let (v0, s1) = next(s0);
+    (mix32(v0 as u32), s1)
+}
+
+// TODO Should this be BigInt?
+pub fn next_integer(lo: isize, hi: isize, mut s0: Seed) -> (isize, Seed) {
+    // Could use lo..hi.into()
+    let v = Uniform::from(lo..hi).sample(&mut s0);
+    (v, s0)
+}
+
+pub fn next_double(lo: f64, hi: f64, mut s0: Seed) -> (f64, Seed) {
+    // Could use lo..hi.into()
+    let v = Uniform::from(lo..hi).sample(&mut s0);
+    (v, s0)
+}
+
+pub fn mix64(x: u64) -> u64 {
+    let y = (x ^ (x >> 33)) * 0xff51afd7ed558ccd;
+    let z = (y ^ (y >> 33)) * 0xc4ceb9fe1a85ec53;
+    z ^ (z >> 33)
+}
+
+#[allow(overflowing_literals)]
+pub fn mix32(x: u32) -> u32 {
+    let y = (x ^ (x >> 33)) * 0xff51afd7ed558ccd;
+    let z = (y ^ (y >> 33)) * 0xc4ceb9fe1a85ec53;
+    z >> 32
+}
+
+pub fn mix64_variant13(x: u64) -> u64 {
+    let y = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
+    let z = (y ^ (y >> 27)) * 0x94d049bb133111eb;
+    z ^ (z >> 31)
+}
+
+pub fn mix_gamma(x: u64) -> u64 {
+    let y = mix64_variant13(x) | 1;
+    let n = (y ^ (y >> 1)).count_ones();
+    if n < 24 {
+        y ^ 0xaaaaaaaaaaaaaaaa
+    } else {
+        y
+    }
+}
+
+// Not sure if the RngCore config intelligently works between 32 and 64 bit
+// arch otherwise we need `#[cfg(target_pointer_width = "64")]`
+impl RngCore for Seed {
+    fn next_u32(&mut self) -> u32 {
+        next_word32(self.clone()).0
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        next_word64(self.clone()).0
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 #[cfg(test)]

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,4 +1,5 @@
 use rand::distributions::{Distribution, Uniform};
+use rand::*;
 use rand_core::{impls, RngCore};
 
 const GOLDEN_GAMMA: u64 = 0x9e3779b97f4a7c15;
@@ -9,21 +10,16 @@ pub struct Seed {
     gamma: u64,
 }
 
-// TODO
+#[inline(never)]
 pub fn global() -> Seed {
-    // Use /dev/urandom on linux
-    // otherwise get POSIX time
-    let value = 0;
-    let gamma = 0;
-    Seed { value, gamma }
+    let mut rng = rand::thread_rng();
+    from(rng.gen())
 }
 
-// TODO
 pub fn random() -> Seed {
     split(global())
 }
 
-// TODO
 pub fn from(x: u64) -> Seed {
     let value = mix64(x);
     let gamma = mix_gamma(x + GOLDEN_GAMMA);
@@ -53,9 +49,8 @@ pub fn next_word32(s0: Seed) -> (u32, Seed) {
     (mix32(v0 as u32), s1)
 }
 
-// TODO Should this be BigInt?
+// XXX Should this be BigInt?
 pub fn next_integer(lo: isize, hi: isize, mut s0: Seed) -> (isize, Seed) {
-    // Could use lo..hi.into()
     let v = Uniform::from(lo..hi).sample(&mut s0);
     (v, s0)
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -73,6 +73,7 @@ pub fn mix64(x: u64) -> u64 {
 }
 
 #[allow(overflowing_literals)]
+#[allow(exceeding_bitshifts)]
 pub fn mix32(x: u32) -> u32 {
     let y = (x ^ (x >> 33)) * 0xff51afd7ed558ccd;
     let z = (y ^ (y >> 33)) * 0xc4ceb9fe1a85ec53;


### PR DESCRIPTION
This patch should at least be a solid start. There are a few funky things, like whether or not we need to worry about the fact that `mix32` literals are overflowing or if we need to target specific int sizes with `#[cfg(target_pointer_width = "64")]` in the `RngCore` trait impl.