### PR TITLE
Loop instead of recurse where possible

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -699,4 +699,9 @@ mod test {
             rand_fn1(global_seed, Size(1))
         );
     }
+
+    #[test]
+    fn test_print_sample() {
+        print_sample(unicode());
+    }
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -28,7 +28,7 @@ pub fn from(x: u64) -> Seed {
 }
 
 pub fn next(Seed { value, gamma }: Seed) -> (u64, Seed) {
-    let value = value + gamma;
+    let value = value.wrapping_add(gamma);
     (value, Seed { value, gamma })
 }
 


### PR DESCRIPTION
This example currently fails with 

```
thread 'gen::test::test_print_sample' has overflowed its stack 
fatal runtime error: stack overflow
```

which is a bummer, but makes sense as we've copied everything 1:1 so far from the F# + Haskell variants. 

We'll need to start changing recursive functions over to imperative approaches; this PR won't do everything, but will start chipping away where it's obvious.