### PR TITLE
Fix nightly warnings: `dyn` trait in signatures

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -32,7 +32,7 @@ where
     g.0
 }
 
-pub fn delay<'a, A>(f: Box<Fn() -> Gen<'a, A> + 'a>) -> Gen<'a, A>
+pub fn delay<'a, A>(f: Box<dyn Fn() -> Gen<'a, A> + 'a>) -> Gen<'a, A>
 where
     A: Clone + 'a,
 {
@@ -113,7 +113,7 @@ where
 // TODO: Turn map into a macro? e.g. map! that is variadic.
 pub fn map2<'a, F, A, B, C>(
     f: Rc<F>,
-) -> impl Fn(Gen<'a, A>) -> Rc<Fn(Gen<'a, B>) -> Gen<'a, C> + 'a>
+) -> impl Fn(Gen<'a, A>) -> Rc<dyn Fn(Gen<'a, B>) -> Gen<'a, C> + 'a>
 where
     A: Clone + 'a,
     B: Clone + 'a,

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 #[derive(Clone)]
 pub struct Lazy<'a, A> {
     value: RefCell<Option<A>>,
-    closure: Rc<'a + Fn() -> A>,
+    closure: Rc<dyn Fn() -> A + 'a>,
 }
 
 impl<'a, A> Lazy<'a, A>

--- a/src/random.rs
+++ b/src/random.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 // repr. between all three that makes sense to Rusts strengths.
 // TODO: Might make sense to have this as a Lazy.
 // TODO: Should the inner function here be an associated type?
-pub type Random<'a, A> = Rc<Fn(Seed, Size) -> A + 'a>;
+pub type Random<'a, A> = Rc<dyn Fn(Seed, Size) -> A + 'a>;
 
 pub fn unsafe_run<'a, A>(seed: Seed, size: Size, r: Random<'a, A>) -> A {
     r(seed, size)
@@ -22,7 +22,7 @@ pub fn run<'a, A>(seed: Seed, size: Size, r: Random<'a, A>) -> A {
     unsafe_run(seed, size.max(Size(1)), r)
 }
 
-pub fn delay<'a, A>(f: Rc<Fn() -> Random<'a, A> + 'a>) -> Random<'a, A>
+pub fn delay<'a, A>(f: Rc<dyn Fn() -> Random<'a, A> + 'a>) -> Random<'a, A>
 where
     A: 'a,
 {

--- a/src/range.rs
+++ b/src/range.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 pub struct Size(pub isize);
 
 #[derive(Clone)]
-pub struct Range<'a, A: 'a>(A, Rc<Fn(Size) -> (A, A) + 'a>);
+pub struct Range<'a, A: 'a>(A, Rc<dyn Fn(Size) -> (A, A) + 'a>);
 
 impl<'a, A> Range<'a, A> {
     pub fn map<F, B>(f: F, Range(z, g): Range<'a, A>) -> Range<'a, B>

--- a/src/shrink.rs
+++ b/src/shrink.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 // This probably could be optimised for an eager language. by simply manipulating the vector
 // directly and doing the inner check, rather than returning the function here for use in a
 // pipeline a la the F# port.
-fn cons_nub<'a, A: 'a>(x: A) -> Box<Fn(Vec<A>) -> Vec<A> + 'a>
+fn cons_nub<'a, A: 'a>(x: A) -> Box<dyn Fn(Vec<A>) -> Vec<A> + 'a>
 where
     A: Integer + FromPrimitive + Copy,
 {


### PR DESCRIPTION
Noticed these are happening on nightly so need to be squashed.

Points for the dedication to backwards compat from rust.