### PR TITLE
Remove fold/fold_forest

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -83,34 +83,6 @@ where
     Tree::new(t, xs)
 }
 
-pub fn fold<A, X, B, F, G>(f: &F, g: &G, t: Tree<A>) -> B
-where
-    A: Clone,
-    B: Clone,
-    X: Clone,
-    // TODO get rid of these static lifetimes
-    F: Fn(A, X) -> B + 'static,
-    G: Fn(Vec<B>) -> X + 'static,
-{
-    let x = t.value();
-    let xs = t.children;
-    f(x, fold_forest(f, g, xs))
-}
-
-pub fn fold_forest<'a, A, X, B, F, G>(f: &F, g: &G, xs: Vec<Tree<A>>) -> X
-where
-    A: Clone,
-    B: Clone,
-    X: Clone,
-    // TODO get rid of these static lifetimes
-    F: Fn(A, X) -> B + 'static,
-    G: Fn(Vec<B>) -> X + 'static,
-{
-    g(xs.into_iter()
-      .map(|x| fold(f, g, x))
-      .collect())
-}
-
 impl<'a, A> PartialEq for Tree<'a, A>
 where
     A: 'a + Clone + PartialEq,


### PR DESCRIPTION
These aren't being used anywhere. I guess they could be useful for round-tripping `unfold` which is most definitely used, but it's in version control anyways. 

cc @jacobstanley 